### PR TITLE
srcclr doesn't find dependencies with Gradle 3+ java plugin syntax

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,15 +14,15 @@ compileJava {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
-    compile group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
-    compile group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
-    compile group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
-    compile group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
-    compile group: 'com.h2database', name: 'h2', version: '1.3.176'
-    compile group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
-    compile group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
+    implementation group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
+    implementation group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
+    implementation group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
+    implementation group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
+    implementation group: 'com.h2database', name: 'h2', version: '1.3.176'
+    implementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
+    implementation group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
     compile group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.9'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 09 12:17:11 SGT 2016
+#Wed Oct 10 00:04:58 ART 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-bin.zip


### PR DESCRIPTION
I want to report the following bug in the srcclr command line agent:

Since Gradle 3.0, the way the dependencies are declared in the java plugin was changed. See e.g. https://docs.gradle.org/current/userguide/java_plugin.html, where it says "`compile` (Deprecated) - Superseded by `implementation`" (some rationale is in https://stackoverflow.com/a/44493379/194640).

I found that the srcclr command line agent (even in the latest version, 3.1.1) is not able to retrieve dependencies using the new syntax. In this branch, you can see that when running `srcclr scan` it finds only orientdb-server as a dependency.

I tried to set the scope to "implementation" by creating a srcclr.yml file in the root of the repository, but it doesn't work.