### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,13 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     compile group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
     compile group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
-    compile group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
-    compile group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
-    compile group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
+    compile group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.4.6'
+    compile group: 'org.keycloak', name: 'keycloak-saml-core', version: '2.5.5.Final'
+    compile group: 'org.neo4j', name: 'neo4j-jmx', version: '3.0.0-M05'
     compile group: 'com.h2database', name: 'h2', version: '1.3.176'
     compile group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
     compile group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
-    compile group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.9'
+    compile group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.11'
 }
 
 defaultTasks 'build'


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To | Breaking |
| --- | --- | --- | --- | --- |
| GRADLE | `org.neo4j:neo4j-jmx` | 1.3 | 3.0.0-M05 | Maybe |
| GRADLE | `com.orientechnologies:orientdb-server` | 2.1.9 | 2.1.11 | Maybe |
| GRADLE | `org.keycloak:keycloak-saml-core` | 1.8.1.Final | 2.5.5.Final | Maybe |
| GRADLE | `org.apache.sling:org.apache.sling.engine` | 2.0.4-incubator | 2.4.6 | Maybe |

<!-- srcclr-pr-id-613319bec6ada4a6790bb04730119426674d5a682e3733bde13fa44a8859bd87 -->
