### PR TITLE
Replaced compile with implementation in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,16 @@ compileJava {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
-    compile group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
-    compile group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
-    compile group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
-    compile group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
-    compile group: 'com.h2database', name: 'h2', version: '1.3.176'
-    compile group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
-    compile group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
-    compile group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.9'
+    testImplementation group: 'junit', name: 'junit', version: '4.11'
+    implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.3m'
+    implementation group: 'org.springframework', name: 'spring-web', version: '3.1.1.RELEASE'
+    implementation group: 'org.apache.sling', name: 'org.apache.sling.engine', version: '2.0.4-incubator'
+    implementation group: 'org.keycloak', name: 'keycloak-saml-core', version: '1.8.1.Final'
+    implementation group: 'org.neo4j', name: 'neo4j-jmx', version: '1.3'
+    implementation group: 'com.h2database', name: 'h2', version: '1.3.176'
+    implementation group: 'org.apache.kafka', name: 'kafka_2.11', version: '0.9.0.1'
+    implementation group: 'net.bull.javamelody', name: 'javamelody-core', version: '1.59.0'
+    implementation group: 'com.orientechnologies', name: 'orientdb-server', version: '2.1.9'
 }
 
 defaultTasks 'build'


### PR DESCRIPTION
The `compile` configuration is now deprecated.

This is still a WIP since the agent needs to be updated to be able to scan this repository by default.